### PR TITLE
ci: create release after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -44,3 +44,21 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
+
+  release:
+    needs: deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create deployment release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOY_URL: https://luizgusmao07.github.io/portfolio/
+        run: |
+          tag="deploy-${GITHUB_RUN_NUMBER}"
+          gh release create "$tag" \
+            --target "$GITHUB_SHA" \
+            --title "Deploy ${tag}" \
+            --notes "Automated release generated after a successful GitHub Pages deployment.\n\nCommit: ${GITHUB_SHA}\nProduction: ${DEPLOY_URL}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ Every commit pushed to `master` triggers:
 
 1. CI via `.github/workflows/ci.yml`.
 2. GitHub Pages build and deploy via `.github/workflows/deploy.yml`.
+3. An automated GitHub Release tagged as `deploy-<run_number>` after a successful deployment.
 
 Production URL:
 
@@ -46,6 +47,7 @@ https://luizgusmao07.github.io/portfolio/
 - `master` is protected.
 - Required status check: `quality`.
 - Force pushes and branch deletion are blocked.
+- Branches are automatically deleted after pull requests are merged.
 
 ## Maintenance guidelines
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Every commit pushed to `master` triggers:
 2. Production build.
 3. GitHub Pages artifact upload.
 4. Deployment to <https://luizgusmao07.github.io/portfolio/>.
+5. Automated GitHub Release tagged as `deploy-<run_number>`.
 
 The Vite base path is configured through `BASE_PATH`. In GitHub Actions it uses:
 
@@ -107,6 +108,7 @@ The previous Vercel deployment was removed and is no longer used.
 - `master` is protected.
 - The `quality` status check is required.
 - Force pushes and branch deletion are blocked.
+- Merged pull request branches are deleted automatically.
 - Use pull requests for regular changes.
 - Keep module-level `AGENTS.md` files updated when responsibilities change.
 
@@ -195,6 +197,7 @@ Cada commit enviado para a branch `master` dispara:
 2. Build de produção.
 3. Upload do artefato do GitHub Pages.
 4. Deploy em <https://luizgusmao07.github.io/portfolio/>.
+5. Release automática no GitHub com tag `deploy-<run_number>`.
 
 O base path do Vite é configurado por `BASE_PATH`. No GitHub Actions, o valor usado é:
 
@@ -210,6 +213,7 @@ O deploy anterior na Vercel foi removido e não é mais utilizado.
 - `master` está protegida.
 - O status check `quality` é obrigatório.
 - Force push e deleção da branch estão bloqueados.
+- Branches de Pull Requests mergeados são deletadas automaticamente.
 - Use Pull Requests para alterações regulares.
 - Mantenha os arquivos `AGENTS.md` atualizados quando responsabilidades mudarem.
 


### PR DESCRIPTION
## Summary\n- Enables automatic deletion of merged PR branches at the repository level.\n- Updates the GitHub Pages deploy workflow to create an automated GitHub Release after successful deploys.\n- Documents the release/deployment behavior in README and AGENTS.md.\n\n## Validation\n- npm run validate