### PR TITLE
fix: use profile photo asset paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,8 @@
     <meta name="twitter:description" content="Portfolio profissional de Luiz Gusmão." />
     <meta name="twitter:image" content="/og-image.svg" />
 
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/jpeg" href="/luiz-profile.jpg" />
+    <link rel="apple-touch-icon" href="/luiz-profile.jpg" />
     <title>Luiz Gusmão | Mobile Software Engineer</title>
   </head>
   <body>

--- a/public/AGENTS.md
+++ b/public/AGENTS.md
@@ -6,9 +6,9 @@ This directory contains static assets served directly by Vite.
 
 Current assets include:
 
-- `favicon.svg`: browser favicon.
+- `favicon.svg`: legacy/custom browser favicon asset kept available.
 - `og-image.svg`: social preview image used by Open Graph/Twitter metadata.
-- `luiz-profile.jpg`: profile photo used in the header and hero section.
+- `luiz-profile.jpg`: profile photo used in the header, hero section and browser tab icon.
 
 ## Maintenance rules
 

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -1,5 +1,7 @@
 export type Language = 'pt' | 'en'
 
+const publicAsset = (fileName: string) => `${import.meta.env.BASE_URL}${fileName}`
+
 export const languages = {
   pt: 'Português',
   en: 'English',
@@ -19,7 +21,7 @@ export const profile = {
     role: 'Mobile Software Engineer',
     company: 'CloudWalk, Inc.',
   },
-  photo: '/luiz-profile.jpg',
+  photo: publicAsset('luiz-profile.jpg'),
   focus: ['Flutter', 'Dart', 'Rust', 'InfinitePay', 'JIM US'],
 } as const
 


### PR DESCRIPTION
## Summary\n- Fixes the profile photo URL so it works under the GitHub Pages /portfolio base path.\n- Uses Luiz's profile photo as the browser tab icon.\n- Keeps the same photo in the header avatar and hero image.\n\n## Validation\n- npm run validate