### PR TITLE
docs: polish readme and release templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,48 @@
-## Summary
+## What changed?
+
+<!-- Describe the change in 2-4 bullets. -->
+
+-
+
+## Why?
+
+<!-- Explain the motivation, bug, design adjustment or maintenance reason. -->
 
 -
 
 ## Validation
 
+<!-- Check everything that applies. -->
+
 - [ ] `npm run validate`
+- [ ] UI checked locally
+- [ ] GitHub Actions passed
+
+## Visual changes
+
+<!-- Add screenshots, screen recordings or notes when the UI changes. -->
+
+- Before:
+- After:
+
+## Release notes
+
+<!-- These notes help the automated deployment release describe merged PRs clearly. -->
+
+### Added
+
+-
+
+### Changed
+
+-
+
+### Fixed
+
+-
 
 ## Checklist
 
-- [ ] Content is up to date
-- [ ] UI was checked on mobile and desktop
-- [ ] Documentation was updated when needed
+- [ ] Content is accurate in PT and EN when applicable
+- [ ] No duplicated profile/contact information was introduced
+- [ ] Related `AGENTS.md` files were updated when module responsibilities changed

--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -1,0 +1,20 @@
+## Added
+
+- _No explicit additions were marked for this deployment._
+
+## Changed
+
+- Deployed the latest changes to GitHub Pages.
+
+## Fixed
+
+- _No explicit fixes were marked for this deployment._
+
+## Merged pull requests and branches
+
+- _Filled automatically by the deployment workflow._
+
+## Validation
+
+- GitHub Actions CI passed on `master`.
+- GitHub Pages deployment completed successfully.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
   pages: write
   id-token: write
+  pull-requests: read
 
 concurrency:
   group: pages
@@ -19,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -51,14 +54,91 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Create deployment release
         env:
           GH_TOKEN: ${{ github.token }}
           DEPLOY_URL: https://luizgusmao07.github.io/portfolio/
         run: |
-          tag="deploy-${GITHUB_RUN_NUMBER}"
+          set -euo pipefail
+
+          tag="v$(date -u +'%Y.%m.%d').${GITHUB_RUN_NUMBER}"
+          previous_tag="$(git describe --tags --abbrev=0 --exclude "$tag" 2>/dev/null || true)"
+
+          if [ -n "$previous_tag" ]; then
+            range="$previous_tag..HEAD"
+          else
+            range="HEAD"
+          fi
+
+          prs_file="/tmp/release-prs.md"
+          commits_file="/tmp/release-commits.md"
+          : > "$prs_file"
+          : > "$commits_file"
+
+          git log --pretty=format:'%s%x09%h' "$range" | while IFS=$'\t' read -r subject short_sha; do
+            pr_number="$(printf '%s' "$subject" | sed -nE 's/.*\(#([0-9]+)\).*/\1/p')"
+
+            if [ -n "$pr_number" ]; then
+              pr_json="$(gh pr view "$pr_number" --json number,title,url,headRefName 2>/dev/null || true)"
+              if [ -n "$pr_json" ]; then
+                pr_title="$(printf '%s' "$pr_json" | jq -r '.title')"
+                pr_url="$(printf '%s' "$pr_json" | jq -r '.url')"
+                pr_branch="$(printf '%s' "$pr_json" | jq -r '.headRefName')"
+                printf -- '- #%s [%s](%s) — `%s`\n' "$pr_number" "$pr_title" "$pr_url" "$pr_branch" >> "$prs_file"
+                continue
+              fi
+            fi
+
+            printf -- '- %s (`%s`)\n' "$subject" "$short_sha" >> "$commits_file"
+          done
+
+          if [ ! -s "$prs_file" ]; then
+            printf -- '- No pull request metadata found for this deployment.\n' > "$prs_file"
+          fi
+
+          if [ ! -s "$commits_file" ]; then
+            printf -- '- All deployment commits were associated with merged pull requests.\n' > "$commits_file"
+          fi
+
+          cat > /tmp/release-notes.md <<EOF
+          ## Added
+
+          - _No explicit additions were marked for this deployment._
+
+          ## Changed
+
+          - Deployed the latest changes to GitHub Pages.
+
+          ## Fixed
+
+          - _No explicit fixes were marked for this deployment._
+
+          ## Merged pull requests and branches
+
+          $(cat "$prs_file")
+
+          ## Other commits
+
+          $(cat "$commits_file")
+
+          ## Deployment
+
+          - Production: ${DEPLOY_URL}
+          - Commit: ${GITHUB_SHA}
+          - Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+          ## Validation
+
+          - GitHub Actions CI passed on `master`.
+          - GitHub Pages deployment completed successfully.
+          EOF
+
+          sed -i 's/^          //' /tmp/release-notes.md
+
           gh release create "$tag" \
             --target "$GITHUB_SHA" \
-            --title "Deploy ${tag}" \
-            --notes "Automated release generated after a successful GitHub Pages deployment.\n\nCommit: ${GITHUB_SHA}\nProduction: ${DEPLOY_URL}"
+            --title "$tag" \
+            --notes-file /tmp/release-notes.md

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/luizgusmao07/portfolio/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/luizgusmao07/portfolio/actions/workflows/ci.yml)
 [![Deploy to GitHub Pages](https://github.com/luizgusmao07/portfolio/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/luizgusmao07/portfolio/actions/workflows/deploy.yml)
 
-> Personal portfolio for Luiz Guilherme Tristão Gusmão — Mobile Software Engineer at CloudWalk.
+> My personal portfolio — Mobile Software Engineer at CloudWalk.
 
 **Live site:** <https://luizgusmao07.github.io/portfolio/>
 
@@ -13,19 +13,21 @@
 
 ### About
 
-This repository contains Luiz Gusmão's personal portfolio, built to present his professional profile, experience, education, skills and contact channels.
+This is my personal portfolio. I use it to present my professional profile, experience, education, skills and contact channels in a clean and maintainable way.
 
-The portfolio currently highlights Luiz as a **Mobile Software Engineer at CloudWalk**, working with **Flutter, Dart, Rust, Product Engineering and AI-assisted Development**.
+I currently work as a **Mobile Software Engineer at CloudWalk**, with a focus on **Flutter, Dart, Rust, Product Engineering and AI-assisted Development**.
 
 ### Features
 
 - Responsive portfolio UI.
+- Portuguese/English language toggle.
 - Light/dark theme with persisted preference.
-- Structured sections: Hero, About, Experience, Skills, Education and Contact.
-- Content-first architecture with profile data isolated in `src/content`.
+- Structured sections: Hero, About, Experience, Skills and Education.
+- Content-first architecture with profile data and localized copy isolated in `src/content`.
 - SEO metadata, Open Graph tags, favicon and social preview image.
 - GitHub Actions CI.
 - Automatic GitHub Pages deployment from `master`.
+- Automated deployment releases.
 - Dependabot updates for npm and GitHub Actions.
 - Pull request template and module-level maintainer docs.
 
@@ -92,13 +94,7 @@ Every commit pushed to `master` triggers:
 2. Production build.
 3. GitHub Pages artifact upload.
 4. Deployment to <https://luizgusmao07.github.io/portfolio/>.
-5. Automated GitHub Release tagged as `deploy-<run_number>`.
-
-The Vite base path is configured through `BASE_PATH`. In GitHub Actions it uses:
-
-```bash
-BASE_PATH=/portfolio/
-```
+5. Automated GitHub Release using the `vYYYY.MM.DD.<run_number>` version pattern.
 
 The previous Vercel deployment was removed and is no longer used.
 
@@ -118,19 +114,21 @@ The previous Vercel deployment was removed and is no longer used.
 
 ### Sobre
 
-Este repositório contém o portfolio pessoal de Luiz Gusmão, criado para apresentar seu perfil profissional, experiências, formação, habilidades e canais de contato.
+Este é o meu portfolio pessoal. Eu uso este projeto para apresentar meu perfil profissional, experiências, formação, habilidades e canais de contato de uma forma limpa e fácil de manter.
 
-O portfolio atualmente posiciona Luiz como **Mobile Software Engineer na CloudWalk**, com foco em **Flutter, Dart, Rust, Product Engineering e AI-assisted Development**.
+Atualmente atuo como **Mobile Software Engineer na CloudWalk**, com foco em **Flutter, Dart, Rust, Product Engineering e AI-assisted Development**.
 
 ### Funcionalidades
 
 - Interface responsiva.
+- Alternância de idioma entre português e inglês.
 - Tema claro/escuro com preferência persistida.
-- Seções estruturadas: Hero, Sobre, Experiência, Skills, Formação e Contato.
-- Arquitetura orientada a conteúdo, com dados profissionais isolados em `src/content`.
+- Seções estruturadas: Hero, Sobre, Experiência, Skills e Formação.
+- Arquitetura orientada a conteúdo, com dados profissionais e textos localizados isolados em `src/content`.
 - SEO básico, Open Graph, favicon e imagem de preview social.
 - CI com GitHub Actions.
 - Deploy automático no GitHub Pages a partir da branch `master`.
+- Releases automáticas a cada deploy.
 - Dependabot para npm e GitHub Actions.
 - Template de Pull Request e documentação modular para manutenção.
 
@@ -197,13 +195,7 @@ Cada commit enviado para a branch `master` dispara:
 2. Build de produção.
 3. Upload do artefato do GitHub Pages.
 4. Deploy em <https://luizgusmao07.github.io/portfolio/>.
-5. Release automática no GitHub com tag `deploy-<run_number>`.
-
-O base path do Vite é configurado por `BASE_PATH`. No GitHub Actions, o valor usado é:
-
-```bash
-BASE_PATH=/portfolio/
-```
+5. Release automática no GitHub seguindo o padrão de versão `vYYYY.MM.DD.<run_number>`.
 
 O deploy anterior na Vercel foi removido e não é mais utilizado.
 


### PR DESCRIPTION
## What changed?\n\n- Improved README wording to use first person instead of talking about me in third person.\n- Removed the Vite base path details from the README.\n- Added a richer PR template with release notes fields.\n- Added a release notes template and updated automated deployment releases to use version-like tags and include merged PR/branch information.\n- Removed the bad generated release/tag `deploy-12`.\n\n## Why?\n\n- Deployment releases should look closer to the manual v1.1.0 release and include what was merged.\n- README should read like my own portfolio project.\n\n## Validation\n\n- npm run validate